### PR TITLE
Concurrential <*> and ap agree

### DIFF
--- a/Concurrential.cabal
+++ b/Concurrential.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                Concurrential
-version:             0.4.0.0
+version:             0.5.0.0
 synopsis:            Mix concurrent and sequential computation
 -- description:         
 homepage:            http://github.com/avieth/Concurrential

--- a/Control/Concurrent/Concurrential.hs
+++ b/Control/Concurrent/Concurrential.hs
@@ -24,7 +24,7 @@ would have been run had they been typical IOs.
 module Control.Concurrent.Concurrential (
 
     Concurrential
-  , ConcurrentialAp
+  , ConcurrentialAp(ConcurrentialAp)
 
   , runConcurrential
 

--- a/Control/Concurrent/Concurrential.hs
+++ b/Control/Concurrent/Concurrential.hs
@@ -26,11 +26,7 @@ module Control.Concurrent.Concurrential (
     Concurrential
   , ConcurrentialAp
 
-  , Runner
-  , Joiner
-
   , runConcurrential
-  , runConcurrentialSimple
 
   , sequentially
   , concurrently
@@ -44,11 +40,12 @@ import Control.Applicative
 import Control.Monad
 import Control.Concurrent.MVar
 import Control.Concurrent.Async hiding (concurrently)
-import Control.Exception
 
+-- | An Async without a type parameter, which can be waited for.
 data SomeAsync where
   SomeAsync :: Async a -> SomeAsync
 
+-- | Wait for a SomeAsync to complete.
 waitSomeAsync :: SomeAsync -> IO ()
 waitSomeAsync (SomeAsync async) = wait async >> return ()
 
@@ -77,98 +74,65 @@ instance Functor m => Functor (Choice m) where
 
 -- | Description of computation which is composed of sequential and concurrent
 --   parts in some monad @m@.
-data Concurrential m t where
-    SCAtom :: Choice m t -> Concurrential m t
-    SCBind :: Concurrential m s -> (s -> Concurrential m t) -> Concurrential m t
-    SCAp :: Concurrential m (r -> t) -> Concurrential m r -> Concurrential m t
+data Concurrential t where
+    SCAtom :: Choice IO t -> Concurrential t
+    SCBind :: Concurrential s -> (s -> Concurrential t) -> Concurrential t
+    SCAp :: Concurrential (r -> t) -> Concurrential r -> Concurrential t
 
-instance Functor m => Functor (Concurrential m) where
+instance Functor Concurrential where
   fmap f sc = case sc of
     SCAtom choice -> SCAtom $ fmap f choice
     SCBind sc k -> SCBind sc ((fmap . fmap) f k)
     SCAp sf sx -> SCAp ((fmap . fmap) f sf) sx
 
-instance Applicative m => Applicative (Concurrential m) where
+instance Applicative Concurrential where
   pure = SCAtom . Sequential . pure
   cf <*> cx = SCBind cf (\f -> SCBind cx (\x -> pure (f x)))
 
-instance Applicative m => Monad (Concurrential m) where
+instance Monad Concurrential where
   return = pure
   (>>=) = SCBind
 
 -- | Concurrential without a Monad instance, but an Applicative instance
 --   which exploits concurrency.
-newtype ConcurrentialAp m t = ConcurrentialAp {
-    unConcurrentialAp :: Concurrential m t
+newtype ConcurrentialAp t = ConcurrentialAp {
+    unConcurrentialAp :: Concurrential t
   }
 
-instance Functor m => Functor (ConcurrentialAp m) where
+instance Functor ConcurrentialAp where
   fmap f sc = ConcurrentialAp $ fmap f (unConcurrentialAp sc)
 
-instance Applicative m => Applicative (ConcurrentialAp m) where
+instance Applicative ConcurrentialAp where
   pure = ConcurrentialAp . pure
   cf <*> cx = ConcurrentialAp $ SCAp (unConcurrentialAp cf) (unConcurrentialAp cx)
-
--- | This corresponds to the notion of a common type of monad transformer:
---   there is some monad g, and then its associated transformer type f, for
---   instance MaybeT = f and Maybe = g
---   If we have an
---   
---     @
---       f m a
---     @
---
---   then we can get an
---
---     @
---       m (g a)
---     @
---
---   Here we're interested in the special case where we can achieve IO (g a).
---   This does not mean we have to be dealing with an f IO a, it could mean
---   that the IO is buried deeper in the transformer stack!
---
---   Motivation: @Async@ functions work with @IO@ and only @IO@, but the @m@
---   parameter of a Concurrential may be some other monad which is capable of
---   performing @IO@, like @Either String IO@ for instance. In order to run
---   computations in this moand through @Async@, we need to know how to get a
---   hold of an @IO@. That's what the runner does.
-type Runner f g = forall a . f a -> IO (g a)
-
--- | A witness of this type proves that g is in some sense compatible with IO:
---   we can bind through it.
-type Joiner g = forall a . g (IO a) -> IO (g a)
 
 -- | Run a Concurrential term with a continuation. We choose CPS here because
 --   it allows us to explot @withAsync@, giving us a guarantee that an
 --   exception in a spawning thread will kill spawned threads.
 runConcurrentialK
-  :: (Functor f, Applicative f, Monad f)
-  => Joiner f
-  -> Runner m f
-  -> Concurrential m t
+  :: Concurrential t
   -- ^ The computation to run.
   -> SomeAsync
   -- ^ The sequential part.
-  -> ((SomeAsync, Async (f t)) -> IO (f r))
+  -> ((SomeAsync, Async t) -> IO r)
   -- ^ The continuation; fst is sequential part, snd is value part.
-  -> IO (f r)
-runConcurrentialK joiner runner sc sequentialPart k = case sc of
+  -> IO r
+runConcurrentialK cc sequentialPart k = case cc of
     SCAtom choice -> case choice of
         -- The async created becomes the sequential part and the value
         -- part. So when another Sequential is encountered, its value part
         -- will have to wait for this computation to complete.
         Sequential em -> withAsync
-                         (waitSomeAsync sequentialPart >> runner em)
+                         (waitSomeAsync sequentialPart >> em)
                          (\async -> k (SomeAsync async, async))
         -- The async created is the value part, but the sequential part
         -- remains the same.
         Concurrent em -> withAsync
-                         (runner em)
+                         (em)
                          (\async -> k (sequentialPart, async))
 
     SCBind sc next ->
-        runConcurrentialK joiner runner sc sequentialPart $ \(sequentialPart, asyncS) -> do
+        runConcurrentialK sc sequentialPart $ \(sequentialPart, asyncS) -> do
         synchronizeSequentialPart <- newEmptyMVar
         let waitAndContinue = do
                 s <- wait asyncS
@@ -177,13 +141,10 @@ runConcurrentialK joiner runner sc sequentialPart k = case sc of
                         wait valuePart
                 let continue = \x ->
                         runConcurrentialK
-                        joiner
-                        runner
                         (next x)
                         sequentialPart
                         synchronizeAndWait
-                let unretracted = fmap continue s
-                fmap join (joiner unretracted)
+                continue s
         -- This is a very sensitive part of the definition. We fire off a thread
         -- to wait for @asyncS@ and then continue through @next@, but we also
         -- create a thread which blocks until the aforementioned has determined
@@ -197,43 +158,26 @@ runConcurrentialK joiner runner sc sequentialPart k = case sc of
             k (SomeAsync sequentialPart, async)
 
     SCAp left right ->
-        runConcurrentialK joiner runner left sequentialPart $ \(sequentialPart, asyncF) ->
-        runConcurrentialK joiner runner right sequentialPart $ \(sequentialPart, asyncX) ->
+        runConcurrentialK left sequentialPart $ \(sequentialPart, asyncF) ->
+        runConcurrentialK right sequentialPart $ \(sequentialPart, asyncX) ->
         let waitAndApply = do
                 f <- wait asyncF
                 x <- wait asyncX
-                return $ f <*> x
+                return $ f x
         in  withAsync waitAndApply (\async -> k (sequentialPart, async))
 
--- | Run a Concurrential term, realizing the effects of the IO-like terms which
+-- | Run a Concurrential term, realizing the effects of the IO terms which
 --   compose it.
 runConcurrential
-  :: (Functor f, Applicative f, Monad f)
-  => Joiner f
-  -> Runner m f
-  -> Concurrential m t
-  -> (Async (f t) -> IO (f r))
+  :: Concurrential t
+  -> (Async t -> IO r)
   -- ^ Similar contract to withAsync; the Async argument is useless outside of
   -- this function.
-  -> IO (f r)
-runConcurrential joiner runner c k = do
+  -> IO r
+runConcurrential cc k = do
     let action = \sequentialPart ->
-            runConcurrentialK joiner runner c (SomeAsync sequentialPart) (k . snd)
+            runConcurrentialK cc (SomeAsync sequentialPart) (k . snd)
     withAsync (return ()) action
-
-runConcurrentialSimple :: Concurrential IO t -> (Async t -> IO r) -> IO r
-runConcurrentialSimple c k = runIdentity <$> runConcurrential simpleJoiner simpleRunner c (continue k)
-
-  where
-
-    continue :: (Async t -> IO r) -> (Async (Identity t) -> IO (Identity r))
-    continue k = \async -> Identity <$> k (fmap runIdentity async)
-
-    simpleJoiner :: Joiner Identity
-    simpleJoiner = fmap Identity . runIdentity
-
-    simpleRunner :: Runner IO Identity
-    simpleRunner = fmap Identity
 
 -- | Create an effect which must be run sequentially.
 --   If a @sequentially io@ appears in a @Concurrential t@ term then it will
@@ -253,8 +197,7 @@ runConcurrentialSimple c k = runIdentity <$> runConcurrential simpleJoiner simpl
 --   important point: @concurrently otherIo@ may be run before, during or after
 --   @sequentially io@! The ordering through applicative combinators is
 --   guaranteed only among sequential terms.
---
-sequentially :: m t -> ConcurrentialAp m t
+sequentially :: IO t -> ConcurrentialAp t
 sequentially = ConcurrentialAp . SCAtom . Sequential
 
 -- | Create an effect which is run concurrently where possible, i.e. whenever it
@@ -268,10 +211,10 @@ sequentially = ConcurrentialAp . SCAtom . Sequential
 --   When running the term @a@, the IO term @io@ will be run concurrently with
 --   @someConcurrential@, but not so in @b@, because monadic composition has
 --   been used.
-concurrently :: m t -> ConcurrentialAp m t
+concurrently :: IO t -> ConcurrentialAp t
 concurrently = ConcurrentialAp . SCAtom . Concurrent
 
 -- | Inject a ConcurrentialAp into Concurrential, losing the
 --   concurrency-enabling Applicative instance but gaining a Monad instance.
-concurrentially :: ConcurrentialAp m t -> Concurrential m t
+concurrentially :: ConcurrentialAp t -> Concurrential t
 concurrentially = unConcurrentialAp

--- a/examples/ReadWrite.hs
+++ b/examples/ReadWrite.hs
@@ -1,0 +1,28 @@
+import Prelude hiding (read, readIO)
+import Control.Applicative
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Concurrential
+import Data.Functor.Identity
+
+readIO :: String -> IO (Maybe String)
+readIO bs = putStrLn ("Reading: " ++ bs) >> return Nothing
+
+writeIO :: String -> Maybe String -> IO ()
+writeIO key value = putStrLn ("Writing: " ++ key ++ ", " ++ show value)
+
+read :: String -> ConcurrentialAp (Maybe String)
+read = concurrently . readIO
+
+write :: String -> Maybe String -> ConcurrentialAp ()
+write key = sequentially . writeIO key
+
+demonstration :: ConcurrentialAp [Maybe String]
+demonstration
+     =  (\x y z -> [x, y, z])
+    <$> (read "A" *> (concurrently (threadDelay 5000000) *> read "A"))
+    <*  write "A" (Just "a")
+    <*  write "B" (Just "b")
+    <*> read "B"
+    <*  write "C" (Just "c")
+    <*> read "C"
+    <*  write "D" (Just "d")


### PR DESCRIPTION
A recent [thread](https://mail.haskell.org/pipermail/haskell-cafe/2015-April/119448.html) on Haskell cafe has convinced me that the disagreeing applicative and monad instances found on `Async`'s `Concurrently` type is a bad idea. With this patch, we have `Concurrential` which is a monad, such that `<*>` and `ap` are interchangeable (`<*>` will not exploit concurrency), and we also have `ConcurrentialAp`, a `newtype` over `Concurrential`, which is not a monad, but is an applicative such that `<*>` _does_ exploit concurrency where possible. `Concurrential` terms are to be built from `ConcurrentialAp` terms via the injection `concurrentially :: ConcurrentialAp a -> Concurrential a`.

This patch also removes the convoluted monad parameter on `Concurrential`.
